### PR TITLE
feat: migrate auth to cookie-based storage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { UserProvider } from './contexts/UserContext';
 import { WebSocketProvider } from './contexts/WebSocketContext';
 import { MatchSelectionProvider } from './contexts/MatchSelectionContext';
-import { USER_TYPES, STORAGE_KEYS } from './config/api.config';
+import { USER_TYPES } from './config/api.config';
 import { createLogger } from './utils/logger';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -101,17 +101,17 @@ const SuspenseWrapper = ({ children }) => (
 );
 
 const ProtectedRoute = ({ children, allowedUserTypes }) => {
-  const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
-  const userType = localStorage.getItem(STORAGE_KEYS.USER_TYPE);
-  
-  if (!token) {
+  const { user } = useAuth();
+  const userType = user?.role || user?.userType;
+
+  if (!user) {
     return <Navigate to="/login" />;
   }
-  
-  if (allowedUserTypes && !allowedUserTypes.includes(userType)) {
+
+  if (allowedUserTypes && userType && !allowedUserTypes.includes(userType)) {
     return <Navigate to="/dashboard" />;
   }
-  
+
   return children;
 };
 

--- a/src/components/EmailForwarding/EmailForwardingGuide.js
+++ b/src/components/EmailForwarding/EmailForwardingGuide.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import { apiClient } from '../../services/api.service';
+import { API_ENDPOINTS } from '../../config/api.config';
 import styles from './EmailForwardingGuide.module.css';
 
 const EmailForwardingGuide = () => {
@@ -12,8 +13,6 @@ const EmailForwardingGuide = () => {
   const [copied, setCopied] = useState(false);
   const [userInstructions, setUserInstructions] = useState(null);
 
-  const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3002';
-
   useEffect(() => {
     fetchData();
   }, []);
@@ -21,19 +20,13 @@ const EmailForwardingGuide = () => {
   const fetchData = async () => {
     try {
       setLoading(true);
-      
-      // Get forwarding email address
-      const emailResponse = await axios.get(`${API_URL}/api/email/forward-address`, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
-      });
-      // Use the forwardToEmail instead of the old donor-specific email
+      const emailResponse = await apiClient.get(API_ENDPOINTS.EMAIL_FORWARD_SETUP);
       setForwardingEmail(emailResponse.data.forwardToEmail || emailResponse.data.email);
       setUserInstructions(emailResponse.data.instructions);
 
-      // Get search templates
-      const templatesResponse = await axios.get(`${API_URL}/api/email/search-templates`);
+      const templatesResponse = await apiClient.get('/api/email/search-templates');
       setSearchTemplates(templatesResponse.data);
-      
+
       setLoading(false);
     } catch (err) {
       setError('Failed to load email forwarding information');

--- a/src/components/EmailForwarding/EmailForwardingModal.js
+++ b/src/components/EmailForwarding/EmailForwardingModal.js
@@ -14,25 +14,13 @@ const EmailForwardingModal = ({ isOpen, onClose }) => {
   useEffect(() => {
     if (isOpen) {
       if (user && user._id) {
-        // Generate unique forwarding email for this user
         const email = `donor-${user._id}@forward.do-nation.space`;
         setForwardingEmail(email);
         setLoading(false);
         setError('');
       } else {
-        // Try to get from localStorage as fallback
-        const token = localStorage.getItem('token');
-        const userId = localStorage.getItem('currentUserId');
-        
-        if (token && userId) {
-          const email = `donor-${userId}@forward.do-nation.space`;
-          setForwardingEmail(email);
-          setLoading(false);
-          setError('');
-        } else {
-          setError('Please log in to view your forwarding email');
-          setLoading(false);
-        }
+        setError('Please log in to view your forwarding email');
+        setLoading(false);
       }
     }
   }, [isOpen, user]);

--- a/src/components/EmailForwarding/ForwardingStatus.js
+++ b/src/components/EmailForwarding/ForwardingStatus.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { apiClient } from '../../services/api.service';
 import { API_ENDPOINTS } from '../../config/api.config';
 import { createLogger } from '../../utils/logger';
+import { useAuth } from '../../contexts/AuthContext';
 import styles from './ForwardingStatus.module.css';
 import '../SharedStyles.css';
 
@@ -15,6 +16,7 @@ const ForwardingStatus = ({ refreshTrigger }) => {
   const [totalPages, setTotalPages] = useState(1);
   const [selectedEmail, setSelectedEmail] = useState(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const { user } = useAuth();
 
   const ITEMS_PER_PAGE = 10;
 
@@ -35,10 +37,8 @@ const ForwardingStatus = ({ refreshTrigger }) => {
       setLoading(true);
       setError('');
       
-      // Check if token exists before making request
-      const token = localStorage.getItem('token');
-      if (!token) {
-        logger.warn('No authentication token found');
+      if (!user) {
+        logger.warn('No authenticated user found');
         setError('Please log in to view forwarded emails');
         setLoading(false);
         return;
@@ -47,7 +47,7 @@ const ForwardingStatus = ({ refreshTrigger }) => {
       logger.debug('Fetching forwarded emails', { 
         page, 
         limit: ITEMS_PER_PAGE,
-        hasToken: !!token 
+        hasAuth: !!user
       });
       
       const response = await apiClient.get(API_ENDPOINTS.EMAIL_FORWARD_STATUS, {
@@ -67,7 +67,7 @@ const ForwardingStatus = ({ refreshTrigger }) => {
       setTotalPages(Math.ceil((response.data.total || 0) / ITEMS_PER_PAGE));
       setLoading(false);
     } catch (err) {
-      logger.error('Failed to fetch forwarded emails', { 
+      logger.error('Failed to fetch forwarded emails', {
         error: err.message,
         status: err.response?.status,
         data: err.response?.data

--- a/src/config/api.config.js
+++ b/src/config/api.config.js
@@ -37,6 +37,7 @@ export const API_ENDPOINTS = {
   USER_LOGIN: '/api/auth/login',
   USER_REGISTER: '/api/users/register',
   USER_PROFILE: '/api/users/me',
+  AUTH_LOGOUT: '/api/auth/logout',
   
   // Business endpoints
   BUSINESS_LOGIN: '/api/business/auth/login',

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,389 +1,114 @@
-import React, { createContext, useState, useContext, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 import axios from 'axios';
-import { API_ENDPOINTS, STORAGE_KEYS, USER_TYPES, getApiUrl } from '../config/api.config';
+import { API_ENDPOINTS, USER_TYPES, getApiUrl } from '../config/api.config';
 import { createLogger } from '../utils/logger';
+
+axios.defaults.withCredentials = true;
 
 const AuthContext = createContext();
 const logger = createLogger('AuthContext');
 
 export const useAuth = () => useContext(AuthContext);
 
-// Set up axios defaults
-const setupAxiosDefaults = (token) => {
-  if (token) {
-    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-  } else {
-    delete axios.defaults.headers.common['Authorization'];
-  }
-};
-
-// Add axios interceptor for token refresh
-axios.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-    
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-      
-      try {
-        const refreshToken = localStorage.getItem('refreshToken');
-        if (refreshToken) {
-          const response = await axios.post(getApiUrl('/auth/refresh-token'), {
-            refreshToken
-          });
-          
-          const { accessToken } = response.data;
-          localStorage.setItem(STORAGE_KEYS.TOKEN, accessToken);
-          setupAxiosDefaults(accessToken);
-          
-          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-          return axios(originalRequest);
-        }
-      } catch (refreshError) {
-        logger.error('Token refresh failed', refreshError);
-        // Clear auth and redirect to login
-        localStorage.clear();
-        window.location.href = '/login';
-      }
-    }
-    
-    return Promise.reject(error);
-  }
-);
-
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const checkAuth = async () => {
-      const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
-      const userType = localStorage.getItem(STORAGE_KEYS.USER_TYPE);
-      if (token && userType) {
-        setupAxiosDefaults(token);
+  const fetchUser = async () => {
+    try {
+      const res = await axios.get(getApiUrl(API_ENDPOINTS.USER_PROFILE));
+      const data = res.data;
+      if (data.role === USER_TYPES.ADMIN) {
+        setUser({ ...data, isAdmin: true, isBusiness: false, isCharity: false });
+      } else {
+        setUser({ ...data, isAdmin: false, isBusiness: false, isCharity: false });
+      }
+      return;
+    } catch (errUser) {
+      try {
+        const resBiz = await axios.get(getApiUrl(API_ENDPOINTS.BUSINESS_PROFILE));
+        setUser({ ...resBiz.data, isBusiness: true, isCharity: false });
+        return;
+      } catch (errBiz) {
         try {
-          let response;
-          if (userType === USER_TYPES.BUSINESS) {
-            response = await axios.get(getApiUrl(API_ENDPOINTS.BUSINESS_PROFILE));
-            setUser({ ...response.data, isBusiness: true, isCharity: false });
-          } else if (userType === USER_TYPES.CHARITY) {
-            response = await axios.get(getApiUrl(API_ENDPOINTS.CHARITY_PROFILE));
-            setUser({ ...response.data, isBusiness: false, isCharity: true });
-          } else if (userType === USER_TYPES.ADMIN) {
-            // For admin, try to get user profile from /api/users/me
-            response = await axios.get(getApiUrl('/users/me'));
-            localStorage.setItem(STORAGE_KEYS.USER_ID, response.data._id || response.data.id);
-            setUser({ ...response.data, isAdmin: true, isBusiness: false, isCharity: false });
-          } else {
-            response = await axios.get(getApiUrl(API_ENDPOINTS.USER_PROFILE));
-            localStorage.setItem(STORAGE_KEYS.USER_ID, response.data._id || response.data.id);
-            setUser({ ...response.data, isBusiness: false, isCharity: false });
-          }
-        } catch (error) {
-          logger.error('Authentication error', { 
-            status: error.response?.status,
-            message: error.message 
-          });
-          if (error.response && error.response.status === 401) {
-            logger.info('Token expired or invalid. Clearing local storage.');
-            clearUserData();
-          }
+          const resChar = await axios.get(getApiUrl(API_ENDPOINTS.CHARITY_PROFILE));
+          setUser({ ...resChar.data, isBusiness: false, isCharity: true });
+          return;
+        } catch (errChar) {
           setUser(null);
         }
-      } else {
-        setUser(null);
-        setupAxiosDefaults(null);
       }
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      await fetchUser();
       setLoading(false);
     };
-    checkAuth();
+    init();
   }, []);
 
-  // Regular user login (also handles admin)
   const login = async (email, password) => {
-    try {
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.USER_LOGIN), { email, password });
-      
-      // Handle new token format
-      const { accessToken, refreshToken, user: userData, token } = response.data;
-      
-      // Use accessToken if available, fallback to token for backward compatibility
-      const authToken = accessToken || token;
-      
-      localStorage.setItem(STORAGE_KEYS.TOKEN, authToken);
-      if (refreshToken) {
-        localStorage.setItem('refreshToken', refreshToken);
-      }
-      
-      // Check if user is admin
-      if (userData && (userData.isAdmin || userData.role === USER_TYPES.ADMIN)) {
-        localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.ADMIN);
-        setUser({ ...userData, isAdmin: true });
-        setupAxiosDefaults(authToken);
-        return userData;
-      }
-      
-      // Regular user flow
-      localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.USER);
-      setupAxiosDefaults(authToken);
-      
-      // If user data is in response, use it; otherwise fetch profile
-      if (userData) {
-        localStorage.setItem(STORAGE_KEYS.USER_ID, userData._id || userData.id);
-        setUser({ ...userData, isBusiness: false, isCharity: false });
-        return userData;
-      } else {
-        const userResponse = await axios.get(getApiUrl(API_ENDPOINTS.USER_PROFILE));
-        localStorage.setItem(STORAGE_KEYS.USER_ID, userResponse.data._id || userResponse.data.id);
-        setUser({ ...userResponse.data, isBusiness: false, isCharity: false });
-        return userResponse.data;
-      }
-    } catch (error) {
-      logger.error('Login error', { message: error.message });
-      throw error;
-    }
+    await axios.post(getApiUrl(API_ENDPOINTS.USER_LOGIN), { email, password });
+    await fetchUser();
   };
 
-  // User signup
   const userSignup = async (name, email, password) => {
-    try {
-      logger.debug('Attempting to register user', { name, email });
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.USER_REGISTER), { name, email, password });
-      logger.debug('Registration successful');
-
-      if (response.data.token) {
-        localStorage.setItem(STORAGE_KEYS.TOKEN, response.data.token);
-        localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.USER);
-        logger.debug('Token stored in localStorage');
-        setupAxiosDefaults(response.data.token);
-
-        const validatedUser = await axios.get(getApiUrl(API_ENDPOINTS.USER_PROFILE));
-        localStorage.setItem(STORAGE_KEYS.USER_ID, validatedUser.data._id || validatedUser.data.id);
-        setUser({ ...validatedUser.data, isBusiness: false, isCharity: false });
-        return validatedUser.data;
-      } else {
-        throw new Error('Registration successful, but no token received.');
-      }
-    } catch (error) {
-      logger.error('User signup error', { 
-        status: error.response?.status,
-        message: error.message 
-      });
-      if (error.response) {
-        if (error.response.status === 400 && error.response.data.error === 'User already exists') {
-          throw new Error('A user with this email already exists. Please try logging in or use a different email.');
-        } else {
-          throw new Error(error.response.data.message || 'An error occurred during registration.');
-        }
-      } else if (error.request) {
-        throw new Error('No response received from the server. Please try again later.');
-      } else {
-        throw new Error('An unexpected error occurred. Please try again.');
-      }
-    }
+    await axios.post(getApiUrl(API_ENDPOINTS.USER_REGISTER), { name, email, password });
+    await fetchUser();
   };
 
-  // Business user login
   const businessLogin = async (emailOrContactEmail, password) => {
-    try {
-      // Support both email and contactEmail fields for compatibility
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.BUSINESS_LOGIN), {
-        email: emailOrContactEmail,
-        contactEmail: emailOrContactEmail,
-        password,
-      });
-      const { token, businessId } = response.data;
-      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-      localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.BUSINESS);
-      localStorage.setItem(STORAGE_KEYS.BUSINESS_ID, businessId);
-      setupAxiosDefaults(token);
-      const businessResponse = await axios.get(getApiUrl(API_ENDPOINTS.BUSINESS_PROFILE));
-      setUser({ ...businessResponse.data, isBusiness: true, isCharity: false });
-      return businessResponse.data;
-    } catch (error) {
-      logger.error('Business login error', { message: error.message });
-      throw error;
-    }
+    await axios.post(getApiUrl(API_ENDPOINTS.BUSINESS_LOGIN), {
+      email: emailOrContactEmail,
+      contactEmail: emailOrContactEmail,
+      password,
+    });
+    await fetchUser();
   };
 
-  // Business user signup
   const businessSignup = async (signupData) => {
-    try {
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.BUSINESS_SIGNUP), signupData);
-      if (response.status === 201 || response.status === 200) {
-        const { token, businessId } = response.data;
-        localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-        localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.BUSINESS);
-        localStorage.setItem(STORAGE_KEYS.BUSINESS_ID, businessId);
-        setupAxiosDefaults(token);
-        const businessResponse = await axios.get(getApiUrl(API_ENDPOINTS.BUSINESS_PROFILE));
-        setUser({ ...businessResponse.data, isBusiness: true, isCharity: false });
-        return businessResponse.data;
-      }
-    } catch (error) {
-      logger.error('Business signup error', { message: error.message });
-      throw error;
-    }
+    await axios.post(getApiUrl(API_ENDPOINTS.BUSINESS_SIGNUP), signupData);
+    await fetchUser();
   };
 
-  // Charity user login
-  const charityLogin = async (emailOrContactEmail, password) => {
-    try {
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.CHARITY_LOGIN), {
-        email: emailOrContactEmail,  // Backend accepts 'email' field
-        contactEmail: emailOrContactEmail,  // Also send contactEmail for compatibility
-        password,
-      });
-      const { token, charity } = response.data;
-      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-      localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.CHARITY);
-      if (charity) {
-        localStorage.setItem(STORAGE_KEYS.CHARITY_ID, charity._id || charity.id || charity.charityId);
-      }
-      setupAxiosDefaults(token);
-      const charityResponse = await axios.get(getApiUrl(API_ENDPOINTS.CHARITY_PROFILE));
-      setUser({ ...charityResponse.data, isBusiness: false, isCharity: true });
-      return charityResponse.data;
-    } catch (error) {
-      logger.error('Charity login error', { message: error.message });
-      throw error;
-    }
+  const charityLogin = async (contactEmail, password) => {
+    await axios.post(getApiUrl(API_ENDPOINTS.CHARITY_LOGIN), { contactEmail, password });
+    await fetchUser();
   };
 
-  // Charity user signup
   const charitySignup = async (signupData) => {
+    await axios.post(getApiUrl(API_ENDPOINTS.CHARITY_SIGNUP), signupData);
+    await fetchUser();
+  };
+
+  const logout = async () => {
     try {
-      const response = await axios.post(getApiUrl(API_ENDPOINTS.CHARITY_SIGNUP), signupData);
-      if (response.status === 201 || response.status === 200) {
-        const { token } = response.data;
-        localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-        localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.CHARITY);
-        setupAxiosDefaults(token);
-        const charityResponse = await axios.get(getApiUrl(API_ENDPOINTS.CHARITY_PROFILE));
-        setUser({ ...charityResponse.data, isBusiness: false, isCharity: true });
-        return charityResponse.data;
-      }
-    } catch (error) {
-      logger.error('Charity signup error', { message: error.message });
-      throw error;
+      await axios.post(getApiUrl(API_ENDPOINTS.AUTH_LOGOUT));
+    } catch (err) {
+      logger.error('Logout failed', err);
     }
-  };
-
-  // Social login
-  const socialLogin = async (token) => {
-    try {
-      logger.debug('Social login: Starting');
-      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-      localStorage.setItem(STORAGE_KEYS.USER_TYPE, USER_TYPES.USER);
-      logger.debug('Social login: Token and userType set in localStorage');
-      setupAxiosDefaults(token);
-
-      logger.debug('Social login: Fetching user data from API');
-      const userResponse = await axios.get(getApiUrl(API_ENDPOINTS.USER_PROFILE));
-      logger.debug('Social login: User data received');
-
-      // Store user ID in localStorage
-      const userId = userResponse.data._id || userResponse.data.id;
-      if (userId) {
-        localStorage.setItem(STORAGE_KEYS.USER_ID, userId);
-        logger.debug('Social login: User ID stored', { userId });
-      }
-
-      setUser({ ...userResponse.data, isBusiness: false, isCharity: false });
-      logger.debug('Social login: User state updated');
-      return userResponse.data;
-    } catch (error) {
-      logger.error('Social login error', {
-        status: error.response?.status,
-        message: error.message
-      });
-      clearUserData();
-      throw error;
-    }
-  };
-
-  // Enhanced clearUserData function
-  const clearUserData = () => {
-    logger.debug('Clearing all user data from localStorage');
-    
-    // Get current user ID for targeted cleaning
-    const currentUserId = localStorage.getItem(STORAGE_KEYS.USER_ID);
-    
-    // Activity-specific data for the current user
-    if (currentUserId) {
-      localStorage.removeItem(`user-${currentUserId}-donation-activity-state`);
-    }
-    
-    // Clear all Activity-related state
-    localStorage.removeItem('donation-activity-state');
-    localStorage.removeItem('donation-activity-state-guest');
-    localStorage.removeItem('searchHistory');
-    localStorage.removeItem('donationStatuses');
-    localStorage.removeItem('selectedTypes');
-    localStorage.removeItem('selectedCharityTypes');
-    
-    // Clear auth-related data
-    Object.values(STORAGE_KEYS).forEach(key => {
-      localStorage.removeItem(key);
-    });
-    
-    // Comprehensive cleanup of any other Activity-specific or user data
-    Object.keys(localStorage).forEach(key => {
-      if (
-        key.startsWith('user-') || 
-        key.startsWith('donation-activity-state') || 
-        key.includes('search') ||
-        key.includes('donation') ||
-        key.includes('charity') ||
-        key.includes('activity')
-      ) {
-        logger.debug(`Removing localStorage item: ${key}`);
-        localStorage.removeItem(key);
-      }
-    });
-    
-    // Reset axios headers
-    setupAxiosDefaults(null);
-    
-    logger.debug('All user data cleared from localStorage');
-  };
-
-  // Enhanced logout function
-  const logout = () => {
-    // Clear all user data
-    clearUserData();
-    
-    // Reset user state
     setUser(null);
-    
-    logger.info('User logged out successfully');
-  };
-
-  // Function to get auth headers
-  const getAuthHeaders = () => {
-    const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
-    logger.debug('Retrieved auth headers');
-    return token ? { Authorization: `Bearer ${token}` } : {};
   };
 
   const value = {
     user,
-    setUser,
+    loading,
     login,
     userSignup,
     businessLogin,
     businessSignup,
     charityLogin,
     charitySignup,
-    socialLogin,
     logout,
-    clearUserData,
-    loading,
-    getAuthHeaders,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={value}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
 };
 
 export default AuthContext;

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import { API_CONFIG, API_ENDPOINTS, SECURITY_HEADERS } from '../config/api.config';
-import { SecureTokenStorage } from '../utils/auth.utils';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('APIService');
@@ -9,24 +8,17 @@ const logger = createLogger('APIService');
 const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
   timeout: API_CONFIG.TIMEOUT,
-  headers: SECURITY_HEADERS
+  headers: SECURITY_HEADERS,
+  withCredentials: API_CONFIG.WITH_CREDENTIALS,
 });
 
-// Request interceptor to add auth token
+// Request interceptor for logging only
 apiClient.interceptors.request.use(
   (config) => {
-    const token = SecureTokenStorage.getToken();
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    
-    // Log request in development
     logger.debug('API Request', {
       method: config.method,
       url: config.url,
-      hasAuth: !!token
     });
-    
     return config;
   },
   (error) => {
@@ -56,9 +48,7 @@ apiClient.interceptors.response.use(
       
       // Handle 401 Unauthorized
       if (response.status === 401) {
-        logger.info('Unauthorized - clearing auth data');
-        SecureTokenStorage.removeToken();
-        // Don't redirect here - let components handle it
+        logger.info('Unauthorized API response');
       }
     } else {
       logger.error('Network Error', { message: error.message });

--- a/src/utils/auth.utils.js
+++ b/src/utils/auth.utils.js
@@ -1,282 +1,95 @@
-import { STORAGE_KEYS } from '../config/api.config';
 import { createLogger } from './logger';
+import { apiClient } from '../services/api.service';
+import { API_ENDPOINTS } from '../config/api.config';
 
 const logger = createLogger('AuthUtils');
 
 /**
- * Secure token storage utility
- * Future: Implement httpOnly cookie support
+ * Token management now relies on httpOnly cookies handled by the server.
+ * Methods in this utility act as no-ops or proxy to server endpoints
+ * and avoid any client-side storage like localStorage.
  */
 export class SecureTokenStorage {
   /**
-   * Store authentication token
-   * @param {string} token - JWT token
+   * Tokens are set by the backend via httpOnly cookies. This method is kept
+   * for backward compatibility but simply logs a warning.
    */
-  static setToken(token) {
-    if (!token) {
-      logger.warn('Attempted to store empty token');
-      return;
-    }
-    
-    // TODO: In production, this should use httpOnly cookies
-    // For now, we use localStorage but log the security concern
-    if (process.env.NODE_ENV === 'production') {
-      logger.warn('Using localStorage for token storage in production - migrate to httpOnly cookies');
-    }
-    
-    try {
-      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-      logger.debug('Token stored successfully');
-    } catch (error) {
-      logger.error('Failed to store token', { error: error.message });
-    }
+  static setToken() {
+    logger.warn('setToken called but tokens are managed by httpOnly cookies');
   }
-  
+
   /**
-   * Retrieve authentication token
-   * @returns {string|null} JWT token or null
+   * Retrieve token. With httpOnly cookies the token is not accessible
+   * from JavaScript, so this always returns null.
    */
   static getToken() {
-    try {
-      const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
-      return token;
-    } catch (error) {
-      logger.error('Failed to retrieve token', { error: error.message });
-      return null;
-    }
+    return null;
   }
-  
+
   /**
-   * Remove authentication token
+   * Remove authentication token by calling the logout endpoint which
+   * clears the cookie on the server side.
    */
-  static removeToken() {
+  static async removeToken() {
     try {
-      localStorage.removeItem(STORAGE_KEYS.TOKEN);
-      logger.debug('Token removed successfully');
+      await apiClient.post(API_ENDPOINTS.AUTH_LOGOUT);
+      logger.debug('Auth cookie cleared via logout endpoint');
     } catch (error) {
-      logger.error('Failed to remove token', { error: error.message });
+      logger.error('Failed to clear auth cookie', { error: error.message });
     }
   }
-  
+
   /**
-   * Check if token exists
-   * @returns {boolean}
+   * Since the token is inaccessible, this simply returns false and should
+   * not be relied upon for auth checks.
    */
   static hasToken() {
-    return !!this.getToken();
+    return false;
   }
 }
 
 /**
- * User data storage utility
+ * In-memory user data storage to replace previous localStorage usage.
+ * This helps components that relied on these helpers while centralising
+ * state in memory only.
  */
 export class UserDataStorage {
-  /**
-   * Store user type
-   * @param {string} userType - Type of user (user, business, charity)
-   */
+  static user = {};
+
   static setUserType(userType) {
-    localStorage.setItem(STORAGE_KEYS.USER_TYPE, userType);
+    this.user.userType = userType;
   }
-  
-  /**
-   * Get user type
-   * @returns {string|null}
-   */
+
   static getUserType() {
-    return localStorage.getItem(STORAGE_KEYS.USER_TYPE);
+    return this.user.userType || null;
   }
-  
-  /**
-   * Store user ID
-   * @param {string} userId - User identifier
-   */
+
   static setUserId(userId) {
-    localStorage.setItem(STORAGE_KEYS.USER_ID, userId);
+    this.user.userId = userId;
   }
-  
-  /**
-   * Get user ID
-   * @returns {string|null}
-   */
+
   static getUserId() {
-    return localStorage.getItem(STORAGE_KEYS.USER_ID);
+    return this.user.userId || null;
   }
-  
-  /**
-   * Store business ID
-   * @param {string} businessId - Business identifier
-   */
+
   static setBusinessId(businessId) {
-    localStorage.setItem(STORAGE_KEYS.BUSINESS_ID, businessId);
+    this.user.businessId = businessId;
   }
-  
-  /**
-   * Get business ID
-   * @returns {string|null}
-   */
+
   static getBusinessId() {
-    return localStorage.getItem(STORAGE_KEYS.BUSINESS_ID);
+    return this.user.businessId || null;
   }
-  
-  /**
-   * Store charity ID
-   * @param {string} charityId - Charity identifier
-   */
+
   static setCharityId(charityId) {
-    localStorage.setItem(STORAGE_KEYS.CHARITY_ID, charityId);
+    this.user.charityId = charityId;
   }
-  
-  /**
-   * Get charity ID
-   * @returns {string|null}
-   */
+
   static getCharityId() {
-    return localStorage.getItem(STORAGE_KEYS.CHARITY_ID);
+    return this.user.charityId || null;
   }
-  
-  /**
-   * Clear all user data
-   */
+
   static clearAll() {
-    Object.values(STORAGE_KEYS).forEach(key => {
-      localStorage.removeItem(key);
-    });
+    this.user = {};
     logger.debug('All user data cleared');
   }
 }
-
-/**
- * Token validation utilities
- */
-export class TokenValidator {
-  /**
-   * Check if token is expired
-   * @param {string} token - JWT token
-   * @returns {boolean}
-   */
-  static isTokenExpired(token) {
-    if (!token) return true;
-    
-    try {
-      // Simple base64 decode (not cryptographically secure, just for exp check)
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const exp = payload.exp;
-      
-      if (!exp) return false; // No expiration set
-      
-      const currentTime = Date.now() / 1000;
-      return currentTime > exp;
-    } catch (error) {
-      logger.error('Failed to check token expiration', { error: error.message });
-      return true; // Assume expired if we can't check
-    }
-  }
-  
-  /**
-   * Get token expiration time
-   * @param {string} token - JWT token
-   * @returns {Date|null}
-   */
-  static getTokenExpiration(token) {
-    if (!token) return null;
-    
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const exp = payload.exp;
-      
-      if (!exp) return null;
-      
-      return new Date(exp * 1000);
-    } catch (error) {
-      logger.error('Failed to get token expiration', { error: error.message });
-      return null;
-    }
-  }
-}
-
-/**
- * Session management utilities
- */
-export class SessionManager {
-  static inactivityTimer = null;
-  static WARNING_TIME = 25 * 60 * 1000; // 25 minutes
-  static LOGOUT_TIME = 30 * 60 * 1000; // 30 minutes
-  
-  /**
-   * Start session timeout monitoring
-   * @param {Function} onWarning - Callback when warning time reached
-   * @param {Function} onTimeout - Callback when session times out
-   */
-  static startSessionTimeout(onWarning, onTimeout) {
-    this.clearSessionTimeout();
-    
-    // Warning timer
-    setTimeout(() => {
-      if (onWarning) onWarning();
-    }, this.WARNING_TIME);
-    
-    // Logout timer
-    this.inactivityTimer = setTimeout(() => {
-      logger.info('Session timed out due to inactivity');
-      if (onTimeout) onTimeout();
-    }, this.LOGOUT_TIME);
-  }
-  
-  /**
-   * Reset session timeout
-   */
-  static resetSessionTimeout() {
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.startSessionTimeout();
-    }
-  }
-  
-  /**
-   * Clear session timeout
-   */
-  static clearSessionTimeout() {
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
-  }
-}
-
-/**
- * Authentication header utilities
- */
-export const getAuthHeaders = () => {
-  const token = SecureTokenStorage.getToken();
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
-
-/**
- * Check if user is authenticated
- * @returns {boolean}
- */
-export const isAuthenticated = () => {
-  const token = SecureTokenStorage.getToken();
-  return token && !TokenValidator.isTokenExpired(token);
-};
-
-/**
- * Get current user role
- * @returns {string|null}
- */
-export const getCurrentUserRole = () => {
-  return UserDataStorage.getUserType();
-};
-
-const authUtils = {
-  SecureTokenStorage,
-  UserDataStorage,
-  TokenValidator,
-  SessionManager,
-  getAuthHeaders,
-  isAuthenticated,
-  getCurrentUserRole
-};
-
-export default authUtils;


### PR DESCRIPTION
## Summary
- Replace localStorage token handling with server-managed httpOnly cookies
- Centralize authentication through revised AuthContext and API service
- Update email forwarding components and routing guard to use context-based auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689adb0064c88323bac76b85142c4df6